### PR TITLE
During preset load, the pole protection is deactivated to make sure …

### DIFF
--- a/Source/PNComponent.h
+++ b/Source/PNComponent.h
@@ -193,6 +193,7 @@ public:
     {
         int filterOrder = getFilterOrderFromParams();
         m_filterOrderMenu.setSelectedItemIndex(filterOrder-1);
+        m_protectionGUI.updateProtectionGUI();
     }
 
     std::function<void()> somethingChanged;

--- a/Source/PresetHandler.cpp
+++ b/Source/PresetHandler.cpp
@@ -434,6 +434,8 @@ void PresetComponent::prevButtonClick()
 
 void PresetComponent::itemchanged()
 {
+	m_presetHandler.setPoleProtection(false);
+
 	repaint();
 	int id = m_presetCombo.getSelectedItemIndex();
 	String itemname;
@@ -471,9 +473,11 @@ void PresetComponent::itemchanged()
 	m_presetHandler.loadPresetAndActivate(itemname);
 	m_somethingchanged = false;
 	
+	m_presetHandler.setPoleProtection(true);
+	//m_presetHandler.setPoleProtection(m_presetHandler.getPoleProtection());
+
 	// update PN component
 	if(somethingChanged != nullptr) somethingChanged();
-
 }
 
 void PresetComponent::categorychanged()

--- a/Source/PresetHandler.h
+++ b/Source/PresetHandler.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include <JuceHeader.h>
+#include "PNParameter.h"
 
 /*#include <juce_gui_extra/juce_gui_extra.h>
 #include <juce_gui_basics/juce_gui_basics.h>
@@ -90,6 +91,16 @@ public:
 			position = -1;
 			return false;
 	    }		
+	}
+
+	// methods to make sure the preset can be loaded 
+	bool getPoleProtection()
+	{
+		return m_vts->getParameter(paramPoleProtectBool.ID)->getValue();
+	}
+	void setPoleProtection(bool isActivated)
+	{
+		m_vts->getParameter(paramPoleProtectBool.ID)->setValue(isActivated);
 	}
 
 // new methods for categories

--- a/Source/ProtectionComponent.h
+++ b/Source/ProtectionComponent.h
@@ -100,6 +100,8 @@ public:
         
     };
 
+    void updateProtectionGUI(){ updateButtons(); };
+
     std::function<void()> protectPoles;
     
 private:


### PR DESCRIPTION
…the preset can be loaded correctly. After the loading process, the pole protection is set to true because the update is not done automatically.